### PR TITLE
fix NameError: name 'basestring' is not defined

### DIFF
--- a/pybleno/Descriptor.py
+++ b/pybleno/Descriptor.py
@@ -9,7 +9,7 @@ import array
 class Descriptor:
     def __init__(self, uuid=None, value=None):
         self.uuid = uuid
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             self.value = array.array('B', [ord(c) for c in value])
         else:
             self.value = value

--- a/pybleno/__init__.py
+++ b/pybleno/__init__.py
@@ -34,7 +34,7 @@ def number_setter(handler):
 def string_getter(handler):
     def encoded_handler():
         result = handler() or ''
-        if result is not None and not isinstance(result, basestring):
+        if result is not None and not isinstance(result, str):
             raise Exception("Unable to encode value as a string - type was [%s]" % type(result).__name__)
         encoded_result = array.array('B', [ord(c) for c in result])
         return encoded_result


### PR DESCRIPTION
The builtin basestring abstract type was removed. Use str instead. From
https://docs.python.org/3.0/whatsnew/3.0.html#text-vs-data-instead-of-unicode-vs-8-bit