### PR TITLE
Add link to original bleno prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Effort has been made to maintain the same code structure to aid in parallel main
 __Note:__ Currently only tested on Linux Raspbian
 
 ## Prerequisites
-Please read the Bleno prerequisites, failure to meet these may result in 'Operation not permitted' errors at runtime.
+Please read the [original nodejs Bleno prerequisites](https://github.com/noble/bleno#prerequisites), failure to meet these may result in 'Operation not permitted' errors at runtime.
 
 ## Install
 


### PR DESCRIPTION
I was confused about the prerequisites. I've realized only later on that it meant nodejs Bleno.