### PR TITLE
Fix handle value confirmation (on Indicate characteristics)

### DIFF
--- a/pybleno/hci_socket/Gap.py
+++ b/pybleno/hci_socket/Gap.py
@@ -96,7 +96,7 @@ class Gap():
             nameBuffer = array.array('B', [ord(elem) for elem in name])
     
             writeUInt8(scanData, 1 + len(nameBuffer), 0)
-            writeUInt8(scanData, 0x08, 1)
+            writeUInt8(scanData, 0x09, 1)  # 0x08 results in 'Short Local Name', 0x09 results in 'Complete Local Name'
             copy(nameBuffer, scanData, 2)
     
         self.startAdvertisingWithEIRData(advertisementData, scanData)

--- a/pybleno/hci_socket/Gatt.py
+++ b/pybleno/hci_socket/Gatt.py
@@ -305,7 +305,7 @@ class Gatt:
             response = self.handlePrepareWriteRequest(request)
         elif requestType == ATT_OP_EXEC_WRITE_REQ:
             response = self.handleExecuteWriteRequest(request)
-        elif requestType == ATT_OP_EXEC_WRITE_REQ:
+        elif requestType == ATT_OP_HANDLE_CNF:
             response = self.handleConfirmation(request)
         else:
             # case ATT_OP_READ_MULTI_REQ:


### PR DESCRIPTION
There's a typo in Gatt.py that causes a Handle Value Confirmation to trigger an Error Response.
This means that there are always errors sent back when an Indicate characteristic is used.