### PR TITLE
Fix handle value confirmation (on Indicate characteristics)

### DIFF
--- a/pybleno/hci_socket/Gatt.py
+++ b/pybleno/hci_socket/Gatt.py
@@ -305,7 +305,7 @@ class Gatt:
             response = self.handlePrepareWriteRequest(request)
         elif requestType == ATT_OP_EXEC_WRITE_REQ:
             response = self.handleExecuteWriteRequest(request)
-        elif requestType == ATT_OP_EXEC_WRITE_REQ:
+        elif requestType == ATT_OP_HANDLE_CNF:
             response = self.handleConfirmation(request)
         else:
             # case ATT_OP_READ_MULTI_REQ:

--- a/pybleno/hci_socket/Gatt.py
+++ b/pybleno/hci_socket/Gatt.py
@@ -305,7 +305,7 @@ class Gatt:
             response = self.handlePrepareWriteRequest(request)
         elif requestType == ATT_OP_EXEC_WRITE_REQ:
             response = self.handleExecuteWriteRequest(request)
-        elif requestType == ATT_OP_HANDLE_CNF:
+        elif requestType == ATT_OP_EXEC_WRITE_REQ:
             response = self.handleConfirmation(request)
         else:
             # case ATT_OP_READ_MULTI_REQ:


### PR DESCRIPTION
There's a typo in Gatt.py that causes a Handle Value Confirmation to trigger an Error Response.
This means that there are always errors sent back when an Indicate characteristic is used.

This fix also fixes the issue that "onIndicate" was never called.