### PR TITLE
Add the 'BLENO_HCI_DEVICE_ID' environment feature

### DIFF
--- a/pybleno/hci_socket/Hci.py
+++ b/pybleno/hci_socket/Hci.py
@@ -16,11 +16,14 @@ class Hci:
 
     def __init__(self):
         self._events = {}
+        try:
+            self._deviceId = int(os.getenv('BLENO_HCI_DEVICE_ID', '0'))
+        except ValueError:
+            self._deviceId = 0
 
-        self._socket = BluetoothHCI(auto_start=False)
+        self._socket = BluetoothHCI(auto_start=False, device_id=self._deviceId)
         self._isDevUp = None
         self._state = None
-        self._deviceId = None
 
         self._handleBuffers = {}
 


### PR DESCRIPTION
Added the `BLENO_HCI_DEVICE_ID` feature in `hci_socket/Hci.py`.

As I understand, the variable `_deviceId` is unused so I used for handling the conversion from `string` to `int`. This is a quick fix that it works in my environment but I don't have the complete vision of the code. Let me know if this breaks something. 