### PR TITLE
Removed deprecated Universal mode for python3.11 compatibility

### DIFF
--- a/pybleno/hci_socket/BluetoothHCI/BluetoothHCI.py
+++ b/pybleno/hci_socket/BluetoothHCI/BluetoothHCI.py
@@ -66,7 +66,7 @@ class BluetoothHCISocketProvider:
 
         self._socket.setblocking(0)
         self.__r, self.__w = os.pipe()
-        self._r = os.fdopen(self.__r, 'rU')
+        self._r = os.fdopen(self.__r, 'r')
         self._w = os.fdopen(self.__w, 'w')
 
     def __del__(self):


### PR DESCRIPTION
Since Python3.11, the Universal mode in fdopen is no longer supported, because it is obsolete. Therefore, I removed it