### PR TITLE
Make Emit a superclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vscode/settings.json

--- a/examples/pizza/Pizza.py
+++ b/examples/pizza/Pizza.py
@@ -1,4 +1,4 @@
-from pybleno.hci_socket import Emit
+from pybleno.hci_socket.Emit import Emit
 import _thread
 import time
 
@@ -28,9 +28,9 @@ PizzaBakeResult = {
   'ON_FIRE':    4
 }
 
-class Pizza():
+class Pizza(Emit):
     def __init__(self):
-        #events.EventEmitter.call(this)
+        super(Pizza, self).__init__()
         self.toppings = PizzaToppings['NONE']
         self.crust = PizzaCrust['NORMAL']
         
@@ -52,5 +52,3 @@ class Pizza():
                 result = PizzaBakeResult['ON_FIRE']
             self.emit('ready', [result]);
         thread.start_new_thread(on_timeout, ())
-
-Emit.Patch(Pizza)

--- a/pybleno/Bleno.py
+++ b/pybleno/Bleno.py
@@ -2,7 +2,6 @@ import array
 import platform
 import sys
 from . import UuidUtil
-from .hci_socket.Emit import Emit
 
 platform = platform.system().lower()
 
@@ -16,6 +15,7 @@ elif platform == 'linux' or platform == 'freebsd' or platform == 'windows' or pl
 else:
     raise Exception('Unsupported platform')
 
+from .hci_socket.Emit import Emit
 
 class Error(Exception):
     def __init__(self, message):

--- a/pybleno/Bleno.py
+++ b/pybleno/Bleno.py
@@ -2,7 +2,7 @@ import array
 import platform
 import sys
 from . import UuidUtil
-from .hci_socket import Emit
+from .hci_socket.Emit import Emit
 
 platform = platform.system().lower()
 
@@ -30,8 +30,9 @@ def is_callable(callback):
         return hasattr(callback, '__call__')
 
 
-class Bleno:
+class Bleno(Emit):
     def __init__(self):
+        super(Bleno, self).__init__()
         self.platform = 'unknown'
         self.state = 'unknown'
         self.address = 'unknown'
@@ -194,5 +195,3 @@ class Bleno:
     def onRssiUpdate(self, rssi):
         self.emit('rssiUpdate', [rssi])
 
-
-Emit.Patch(Bleno)

--- a/pybleno/BlenoPrimaryService.py
+++ b/pybleno/BlenoPrimaryService.py
@@ -3,9 +3,11 @@ import json
 from .hci_socket import Emit
 
 
-class BlenoPrimaryService(dict):
+class BlenoPrimaryService:
     def __init__(self, options):
         super(BlenoPrimaryService, self).__init__()
+        self._dict = {}
+
         self['uuid'] = UuidUtil.removeDashes(options['uuid'])
         self['characteristics'] = options['characteristics'] if 'characteristics' in options else []
 
@@ -16,55 +18,55 @@ class BlenoPrimaryService(dict):
         })
 
     def __setitem__(self, key, item):
-        self.__dict__[key] = item
+        self._dict[key] = item
 
     def __getitem__(self, key):
-        return self.__dict__[key]
+        return self._dict[key]
 
     def __repr__(self):
-        return repr(self.__dict__)
+        return repr(self._dict)
 
     def __len__(self):
-        return len(self.__dict__)
+        return len(self._dict)
 
     def __delitem__(self, key):
-        del self.__dict__[key]
+        del self._dict[key]
 
     def clear(self):
-        return self.__dict__.clear()
+        return self._dict.clear()
 
     def copy(self):
-        return self.__dict__.copy()
+        return self._dict.copy()
 
     def has_key(self, k):
-        return k in self.__dict__
+        return k in self._dict
 
     def update(self, *args, **kwargs):
-        return self.__dict__.update(*args, **kwargs)
+        return self._dict.update(*args, **kwargs)
 
     def keys(self):
-        return self.__dict__.keys()
+        return self._dict.keys()
 
     def values(self):
-        return self.__dict__.values()
+        return self._dict.values()
 
     def items(self):
-        return self.__dict__.items()
+        return self._dict.items()
 
     def pop(self, *args):
-        return self.__dict__.pop(*args)
+        return self._dict.pop(*args)
 
     def __cmp__(self, dict_):
-        return self.__cmp__(self.__dict__, dict_)
+        return self.__cmp__(self._dict, dict_)
 
     def __contains__(self, item):
-        return item in self.__dict__
+        return item in self._dict
 
     def __iter__(self):
-        return iter(self.__dict__)
+        return iter(self._dict)
 
     def __unicode__(self):
-        return unicode(repr(self.__dict__))
+        return unicode(repr(self._dict))
 
 
 Emit.Patch(BlenoPrimaryService)

--- a/pybleno/BlenoPrimaryService.py
+++ b/pybleno/BlenoPrimaryService.py
@@ -1,9 +1,9 @@
 from . import UuidUtil
 import json
-from .hci_socket import Emit
+from .hci_socket.Emit import Emit
 
 
-class BlenoPrimaryService:
+class BlenoPrimaryService(Emit):
     def __init__(self, options):
         super(BlenoPrimaryService, self).__init__()
         self._dict = {}
@@ -68,5 +68,3 @@ class BlenoPrimaryService:
     def __unicode__(self):
         return unicode(repr(self._dict))
 
-
-Emit.Patch(BlenoPrimaryService)

--- a/pybleno/Characteristic.py
+++ b/pybleno/Characteristic.py
@@ -2,7 +2,7 @@ from .hci_socket import Emit
 from . import UuidUtil
 
 
-class Characteristic(dict):
+class Characteristic:
     RESULT_SUCCESS = 0x00
     RESULT_INVALID_OFFSET = 0x07
     RESULT_ATTR_NOT_LONG = 0x0b
@@ -11,6 +11,8 @@ class Characteristic(dict):
 
     def __init__(self, options=None):
         super(Characteristic, self).__init__()
+        self._dict = {}
+
         if options is None:
             options = {}
         self['uuid'] = UuidUtil.removeDashes(options['uuid'])
@@ -71,55 +73,55 @@ class Characteristic(dict):
         pass
 
     def __setitem__(self, key, item):
-        self.__dict__[key] = item
+        self._dict[key] = item
 
     def __getitem__(self, key):
-        return self.__dict__[key]
+        return self._dict[key]
 
     def __repr__(self):
-        return repr(self.__dict__)
+        return repr(self._dict)
 
     def __len__(self):
-        return len(self.__dict__)
+        return len(self._dict)
 
     def __delitem__(self, key):
-        del self.__dict__[key]
+        del self._dict[key]
 
     def clear(self):
-        return self.__dict__.clear()
+        return self._dict.clear()
 
     def copy(self):
-        return self.__dict__.copy()
+        return self._dict.copy()
 
     def has_key(self, k):
-        return k in self.__dict__
+        return k in self._dict
 
     def update(self, *args, **kwargs):
-        return self.__dict__.update(*args, **kwargs)
+        return self._dict.update(*args, **kwargs)
 
     def keys(self):
-        return self.__dict__.keys()
+        return self._dict.keys()
 
     def values(self):
-        return self.__dict__.values()
+        return self._dict.values()
 
     def items(self):
-        return self.__dict__.items()
+        return self._dict.items()
 
     def pop(self, *args):
-        return self.__dict__.pop(*args)
+        return self._dict.pop(*args)
 
     def __cmp__(self, dict_):
-        return self.__dict__.__cmp__(dict_)
+        return self._dict.__cmp__(dict_)
 
     def __contains__(self, item):
-        return item in self.__dict__
+        return item in self._dict
 
     def __iter__(self):
-        return iter(self.__dict__)
+        return iter(self._dict)
 
     def __unicode__(self):
-        return unicode(repr(self.__dict__))
+        return unicode(repr(self._dict))
 
 
 Emit.Patch(Characteristic)

--- a/pybleno/Characteristic.py
+++ b/pybleno/Characteristic.py
@@ -1,8 +1,8 @@
-from .hci_socket import Emit
+from .hci_socket.Emit import Emit
 from . import UuidUtil
 
 
-class Characteristic:
+class Characteristic(Emit):
     RESULT_SUCCESS = 0x00
     RESULT_INVALID_OFFSET = 0x07
     RESULT_ATTR_NOT_LONG = 0x0b
@@ -123,5 +123,3 @@ class Characteristic:
     def __unicode__(self):
         return unicode(repr(self._dict))
 
-
-Emit.Patch(Characteristic)

--- a/pybleno/hci_socket/AclStream.py
+++ b/pybleno/hci_socket/AclStream.py
@@ -1,9 +1,10 @@
-from . import Emit
+from .Emit import Emit
 from .Smp import Smp
 
 
-class AclStream:
+class AclStream(Emit):
     def __init__(self, hci, handle, localAddressType, localAddress, remoteAddressType, remoteAddress):
+        super(AclStream, self).__init__()
         self._hci = hci
         self._handle = handle
         self.encrypted = False
@@ -17,7 +18,7 @@ class AclStream:
         if data:
             self.emit('data', [cid, data])
         else:
-            self.emit('end', []);
+            self.emit('end', [])
 
     def pushEncrypt(self, encrypt):
         self.encrypted = True if encrypt else False
@@ -27,5 +28,3 @@ class AclStream:
     def pushLtkNegReply(self):
         self.emit('ltkNegReply', [])
 
-
-Emit.Patch(AclStream)

--- a/pybleno/hci_socket/Bindings.py
+++ b/pybleno/hci_socket/Bindings.py
@@ -1,5 +1,5 @@
 import platform
-from . import Emit
+from .Emit import Emit
 
 from .Hci import Hci
 from .Gap import Gap
@@ -7,8 +7,9 @@ from .Gatt import Gatt
 from .AclStream import AclStream
 
 
-class BlenoBindings:
+class BlenoBindings(Emit):
     def __init__(self):
+        super(BlenoBindings, self).__init__()
         self._state = None
 
         self._advertising = False
@@ -168,5 +169,3 @@ class BlenoBindings:
         if (self._handle == handle and self._aclStream):
             self._aclStream.push(cid, data)
 
-
-Emit.Patch(BlenoBindings)

--- a/pybleno/hci_socket/Emit.py
+++ b/pybleno/hci_socket/Emit.py
@@ -1,43 +1,31 @@
-def on(self, event, handler):
-    self._events = self._events
-    handlers = self._events[event] = self._events[event] if event in self._events else []
-    handlers.append(handler)
-
-
-def off(self, event, handler):
-    handlers = self._events[event] = self._events[event] if event in self._events else []
-    handlers.remove(handler)
-
-
-def emit(self, event, arguments):
-    # print self._events
-    # print self._events[event]
-    handlers = self._events[event] if event in self._events else []
-    for handler in handlers:
-        handler(*arguments)
-
-
-def once(self, event, arguments, handler):
-    def temporary_handler(*arguments):
-        self.off(event, temporary_handler)
-        handler(*arguments)
-
-    self.on(event, temporary_handler)
-
-
-# class Emit:
-def Patch(clzz):
-    clzz.on = on
-    clzz.emit = emit
-    clzz.off = off
-    clzz.once = once
-
-    old_init = clzz.__init__
-
-    def new_init(self, *k, **kw):
+class Emit:
+    def __init__(self):
         self._events = {}
-        old_init(self, *k, **kw)
 
-    clzz.__init__ = new_init
+    def on(self, event, handler):
+        if event not in self._events:
+            self._events[event] = []
 
-# Patch = staticmethod(Patch)
+        self._events[event].append(handler)
+
+    def off(self, event, handler):
+        if event not in self._events:
+            return
+
+        self._events[event].remove(handler)
+
+    def emit(self, event, arguments):
+        # print self._events
+        # print self._events[event]
+        if event not in self._events:
+            return
+
+        for handler in self._events[event]:
+            handler(*arguments)
+
+    def once(self, event, arguments, handler):
+        def temporary_handler(*arguments):
+            self.off(event, temporary_handler)
+            handler(*arguments)
+
+        self.on(event, temporary_handler)

--- a/pybleno/hci_socket/Gap.py
+++ b/pybleno/hci_socket/Gap.py
@@ -1,6 +1,7 @@
 import platform
 import array
-from . import Emit, Hci
+from . import Hci
+from .Emit import Emit
 from .Io import *
 
 isLinux = (platform.system() == 'Linux')
@@ -8,8 +9,9 @@ isIntelEdison = False  # isLinux && (os.release().indexOf('edison') !== -1)
 isYocto = False  # isLinux && (os.release().indexOf('yocto') !== -1)
 
 
-class Gap:
+class Gap(Emit):
     def __init__(self, hci):
+        super(Gap, self).__init__()
         self._hci = hci
 
         self._advertiseState = None
@@ -193,5 +195,3 @@ class Gap:
 
             self.emit('advertisingStop', [])
 
-
-Emit.Patch(Gap)

--- a/pybleno/hci_socket/Gatt.py
+++ b/pybleno/hci_socket/Gatt.py
@@ -1,4 +1,4 @@
-from . import Emit
+from .Emit import Emit
 import os
 import platform
 import array
@@ -63,8 +63,9 @@ ATT_ECODE_INSUFF_RESOURCES = 0x11
 ATT_CID = 0x0004
 
 
-class Gatt:
+class Gatt(Emit):
     def __init__(self):
+        super(Gatt, self).__init__()
         self.maxMtu = 256
         self._mtu = 23
         self._preparedWriteRequest = None
@@ -887,5 +888,3 @@ class Gatt:
 
             self._lastIndicatedAttribute = None
 
-
-Emit.Patch(Gatt)

--- a/pybleno/hci_socket/Hci.py
+++ b/pybleno/hci_socket/Hci.py
@@ -1,7 +1,7 @@
 import threading
 import math
 import time
-from . import Emit
+from .Emit import Emit
 from .BluetoothHCI import *
 # from constants import *
 from .constants2 import *
@@ -11,11 +11,11 @@ from .Io import *
 from .HciStatus import *
 
 
-class Hci:
+class Hci(Emit):
     STATUS_MAPPER = STATUS_MAPPER
 
     def __init__(self):
-        self._events = {}
+        super(Hci, self).__init__()
 
         self._socket = BluetoothHCI(auto_start=False)
         self._isDevUp = None
@@ -602,5 +602,3 @@ class Hci:
             time.sleep(1)
         # setTimeout(this.pollIsDevUp.bind(this), 1000);
 
-
-Emit.Patch(Hci)

--- a/pybleno/hci_socket/Smp.py
+++ b/pybleno/hci_socket/Smp.py
@@ -1,4 +1,4 @@
-from . import Emit
+from .Emit import Emit
 import array
 from .Io import *
 
@@ -15,8 +15,9 @@ SMP_MASTER_IDENT = 0x07
 SMP_UNSPECIFIED = 0x08
 
 
-class Smp:
+class Smp(Emit):
     def __init__(self, aclStream, localAddressType, localAddress, remoteAddressType, remoteAddress):
+        super(Smp, self).__init__()
         self._aclStream = aclStream
 
         self._iat = array.array('B', [0x01 if (remoteAddressType == 'random') else 0x00])
@@ -139,5 +140,3 @@ class Smp:
     def write(self, data):
         self._aclStream.write(SMP_CID, data)
 
-
-Emit.Patch(Smp)


### PR DESCRIPTION
Pyright does not understand how previously the event emitter was set up. This PR refactors the patch into a superclass, which better aligns with the bleno source anyway.