### PR TITLE
Fix a few porting bugs

### DIFF
--- a/pybleno/hci_socket/Gatt.py
+++ b/pybleno/hci_socket/Gatt.py
@@ -229,7 +229,7 @@ class Gatt:
 
     def onAclStreamEnd(self):
         self._aclStream.off('data', self.onAclStreamData)
-        self._aclStream.removeListener('end', self.onAclStreamEnd)
+        self._aclStream.off('end', self.onAclStreamEnd)
 
         for i in range(0, len(self._handles)):
             if (i in self._handles and self._handles[i]['type'] == 'descriptor' and self._handles[i][

--- a/pybleno/hci_socket/Gatt.py
+++ b/pybleno/hci_socket/Gatt.py
@@ -237,7 +237,7 @@ class Gatt:
 
                 self._handles[i]['value'] = array.array('B', [0x00, 0x00])
 
-                if self._handles[i]['attribute'] and self._handles[i]['attribute'].emit:
+                if self._handles[i]['attribute'] and hasattr(self._handles[i]['attribute'], "emit"):
                     self._handles[i]['attribute'].emit('unsubscribe', [])
 
     def send(self, data):
@@ -882,7 +882,7 @@ class Gatt:
 
     def handleConfirmation(self, request):
         if self._lastIndicatedAttribute:
-            if self._lastIndicatedAttribute.emit:
+            if hasattr(self._lastIndicatedAttribute, "emit"):
                 self._lastIndicatedAttribute.emit('indicate', [])
 
             self._lastIndicatedAttribute = None

--- a/pybleno/hci_socket/Hci.py
+++ b/pybleno/hci_socket/Hci.py
@@ -88,7 +88,7 @@ class Hci:
         writeUInt8(cmd, 0x00, 3)
 
         # debug('reset');
-        self.write_buffer(cmd)
+        self.write(cmd)
 
     def readLeHostSupported(self):
         cmd = array.array('B', [0] * 4)


### PR DESCRIPTION
At a few places, the code still contains the original JS patterns:
 - attribute checks
 - some methods were renamed in pybleno, but code still calls the js names
This PR fixes these issues where I could find them.