### PR TITLE
HCI: increase maxMtu to 128 for Realtek chips

### DIFF
--- a/pybleno/hci_socket/Bindings.py
+++ b/pybleno/hci_socket/Bindings.py
@@ -109,7 +109,7 @@ class BlenoBindings:
             self._gatt.maxMtu = 23
         elif (manufacturer == 93):
             # Realtek Semiconductor Corporation
-            self._gatt.maxMtu = 23
+            self._gatt.maxMtu = 128
 
     def onAdvertisingStart(self, error):
         self.emit('advertisingStart', [error])


### PR DESCRIPTION
- increase maxMtu to 128 for Realtek chips (enables GATT notify with large message size)

Tested with ASUS USB-BT500:

  usb 1-4: new full-speed USB device number 6 using xhci_hcd
  usb 1-4: New USB device found, idVendor=0b05, idProduct=190e, bcdDevice= 2.00
  usb 1-4: New USB device strings: Mfr=1, Product=2, SerialNumber=3
  usb 1-4: Product: ASUS USB-BT500
  usb 1-4: Manufacturer: Realtek
  usb 1-4: SerialNumber: 00E04C239987
  Bluetooth: hci0: RTL: examining hci_ver=0a hci_rev=000b lmp_ver=0a lmp_subver=8761
  Bluetooth: hci0: RTL: rom_version status=0 version=1
  Bluetooth: hci0: RTL: loading rtl_bt/rtl8761bu_fw.bin
  Bluetooth: hci0: RTL: loading rtl_bt/rtl8761bu_config.bin
  Bluetooth: hci0: RTL: cfg_sz 6, total sz 30210
  Bluetooth: hci0: RTL: fw version 0xdfc6d922
  Bluetooth: MGMT ver 1.23

Notes:
  - larger maxMtu values (>248) will lead to failures, e.g. 251 will already break the GATT characteristic handshake