### PR TITLE
HCI: increase maxMtu to 128 for Realtek chips (accumulated)

### DIFF
--- a/pybleno/hci_socket/Bindings.py
+++ b/pybleno/hci_socket/Bindings.py
@@ -109,7 +109,7 @@ class BlenoBindings:
             self._gatt.maxMtu = 23
         elif (manufacturer == 93):
             # Realtek Semiconductor Corporation
-            self._gatt.maxMtu = 23
+            self._gatt.maxMtu = 128
 
     def onAdvertisingStart(self, error):
         self.emit('advertisingStart', [error])

--- a/pybleno/hci_socket/Hci.py
+++ b/pybleno/hci_socket/Hci.py
@@ -55,7 +55,7 @@ class Hci:
         opcode = 0
 
         # debug('setting filter to: ' + filter.toString('hex'))
-        filter = struct.pack("<LLLH", typeMask, eventMask1, eventMask2, opcode)
+        filter = struct.pack("<LLLHxx", typeMask, eventMask1, eventMask2, opcode)
         self._socket.set_filter(filter)
 
     def setEventMask(self):


### PR DESCRIPTION
- Fix hci_ufilter struct member alignment padding to pad opcode by 2 bytes. #63
(taken from https://github.com/Adam-Langley/pybleno/pull/64)

- HCI: increase maxMtu to 128 for Realtek chips
(taken from https://github.com/Adam-Langley/pybleno/pull/65)

Accumulated pull requst/branch for easy access by customer.