### PR TITLE
HCI: increase maxMtu to 128 for Intel/Realtek chips (accumulated)

### DIFF
--- a/pybleno/hci_socket/Bindings.py
+++ b/pybleno/hci_socket/Bindings.py
@@ -106,7 +106,7 @@ class BlenoBindings:
     def onReadLocalVersion(self, hciVer, hciRev, lmpVer, manufacturer, lmpSubVer):
         if (manufacturer == 2):
             # Intel Corporation
-            self._gatt.maxMtu = 23
+            self._gatt.maxMtu = 128
         elif (manufacturer == 93):
             # Realtek Semiconductor Corporation
             self._gatt.maxMtu = 128

--- a/pybleno/hci_socket/Bindings.py
+++ b/pybleno/hci_socket/Bindings.py
@@ -109,7 +109,7 @@ class BlenoBindings:
             self._gatt.maxMtu = 23
         elif (manufacturer == 93):
             # Realtek Semiconductor Corporation
-            self._gatt.maxMtu = 23
+            self._gatt.maxMtu = 128
 
     def onAdvertisingStart(self, error):
         self.emit('advertisingStart', [error])

--- a/pybleno/hci_socket/Hci.py
+++ b/pybleno/hci_socket/Hci.py
@@ -55,7 +55,7 @@ class Hci:
         opcode = 0
 
         # debug('setting filter to: ' + filter.toString('hex'))
-        filter = struct.pack("<LLLH", typeMask, eventMask1, eventMask2, opcode)
+        filter = struct.pack("<LLLHxx", typeMask, eventMask1, eventMask2, opcode)
         self._socket.set_filter(filter)
 
     def setEventMask(self):

--- a/pybleno/hci_socket/Hci.py
+++ b/pybleno/hci_socket/Hci.py
@@ -16,11 +16,14 @@ class Hci:
 
     def __init__(self):
         self._events = {}
+        try:
+            self._deviceId = int(os.getenv('BLENO_HCI_DEVICE_ID', '0'))
+        except ValueError:
+            self._deviceId = 0
 
-        self._socket = BluetoothHCI(auto_start=False)
+        self._socket = BluetoothHCI(auto_start=False, device_id=self._deviceId)
         self._isDevUp = None
         self._state = None
-        self._deviceId = None
 
         self._handleBuffers = {}
 

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,14 @@ from distutils.core import setup
 setup(
   name = 'pybleno',
   packages = ['pybleno', 'pybleno/hci_socket',  'pybleno/hci_socket/BluetoothHCI'], # this must be the same as the name above
-  version = '0.11',
+  # v0.11.1:
+  #  - 'Fix hci_ufilter struct member alignment padding to pad opcode by 2 bytes. #63'
+  version = '0.11.1',
   description = 'A direct port of the Bleno bluetooth LE peripheral role library to Python2/3',
   author = 'Adam Langley',
   author_email = 'github.com@irisdesign.co.nz',
   url = 'https://github.com/Adam-Langley/pybleno', # use the URL to the github repo
-  download_url = 'https://github.com/Adam-Langley/pybleno/archive/0.9.tar.gz', # I'll explain this in a second
+  download_url = 'https://github.com/pseiderer/pybleno/archive/refs/tags/v0.11.1.tar.gz', # I'll explain this in a second
   keywords = ['Bluetooth', 'Bluetooth Smart', 'BLE', 'Bluetooth Low Energy'], # arbitrary keywords
   classifiers=[
       'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,14 @@ setup(
   #  - 'HCI: increase maxMtu to 128 for Realtek chips'
   # v0.11.3:
   #  - 'HCI: increase maxMtu to 128 for Intel chips'
-  version = '0.11.3',
+  # v0.11.4:
+  #  - 'Add the 'BLENO_HCI_DEVICE_ID' environment feature'
+  version = '0.11.4',
   description = 'A direct port of the Bleno bluetooth LE peripheral role library to Python2/3',
   author = 'Adam Langley',
   author_email = 'github.com@irisdesign.co.nz',
   url = 'https://github.com/Adam-Langley/pybleno', # use the URL to the github repo
-  download_url = 'https://github.com/pseiderer/pybleno/archive/refs/tags/v0.11.3.tar.gz', # I'll explain this in a second
+  download_url = 'https://github.com/pseiderer/pybleno/archive/refs/tags/v0.11.4.tar.gz', # I'll explain this in a second
   keywords = ['Bluetooth', 'Bluetooth Smart', 'BLE', 'Bluetooth Low Energy'], # arbitrary keywords
   classifiers=[
       'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,14 @@ setup(
   #  - 'Fix hci_ufilter struct member alignment padding to pad opcode by 2 bytes. #63'
   # v0.11.2:
   #  - 'HCI: increase maxMtu to 128 for Realtek chips'
-  version = '0.11.2',
+  # v0.11.3:
+  #  - 'HCI: increase maxMtu to 128 for Intel chips'
+  version = '0.11.3',
   description = 'A direct port of the Bleno bluetooth LE peripheral role library to Python2/3',
   author = 'Adam Langley',
   author_email = 'github.com@irisdesign.co.nz',
   url = 'https://github.com/Adam-Langley/pybleno', # use the URL to the github repo
-  download_url = 'https://github.com/pseiderer/pybleno/archive/refs/tags/v0.11.2.tar.gz', # I'll explain this in a second
+  download_url = 'https://github.com/pseiderer/pybleno/archive/refs/tags/v0.11.3.tar.gz', # I'll explain this in a second
   keywords = ['Bluetooth', 'Bluetooth Smart', 'BLE', 'Bluetooth Low Energy'], # arbitrary keywords
   classifiers=[
       'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -4,12 +4,14 @@ setup(
   packages = ['pybleno', 'pybleno/hci_socket',  'pybleno/hci_socket/BluetoothHCI'], # this must be the same as the name above
   # v0.11.1:
   #  - 'Fix hci_ufilter struct member alignment padding to pad opcode by 2 bytes. #63'
-  version = '0.11.1',
+  # v0.11.2:
+  #  - 'HCI: increase maxMtu to 128 for Realtek chips'
+  version = '0.11.2',
   description = 'A direct port of the Bleno bluetooth LE peripheral role library to Python2/3',
   author = 'Adam Langley',
   author_email = 'github.com@irisdesign.co.nz',
   url = 'https://github.com/Adam-Langley/pybleno', # use the URL to the github repo
-  download_url = 'https://github.com/pseiderer/pybleno/archive/refs/tags/v0.11.1.tar.gz', # I'll explain this in a second
+  download_url = 'https://github.com/pseiderer/pybleno/archive/refs/tags/v0.11.2.tar.gz', # I'll explain this in a second
   keywords = ['Bluetooth', 'Bluetooth Smart', 'BLE', 'Bluetooth Low Energy'], # arbitrary keywords
   classifiers=[
       'Programming Language :: Python :: 2.7',


### PR DESCRIPTION
- Fix hci_ufilter struct member alignment padding to pad opcode by 2 bytes. #63
(taken from https://github.com/Adam-Langley/pybleno/pull/64)

- setup.py: bump version to 0.11.1

- HCI: increase maxMtu to 128 for Realtek chips
(taken from https://github.com/Adam-Langley/pybleno/pull/65)

- setup.py: bump version to 0.11.2

- HCI: increase maxMtu to 128 for Intel chips

- setup.py: bump version to 0.11.3

- Add the 'BLENO_HCI_DEVICE_ID' environment feature
(taken from https://github.com/Adam-Langley/pybleno/pull/53)

- setup.py: bump version to 0.11.4

Accumulated pull requst/branch for easy access by customer.